### PR TITLE
Fix missing space in DISABLE_CERT_VAL elif condition

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
           elif [ "$CLIENT_CERT" != "" ]; then
             if [ "$DISABLE_CERT_VAL" == "true" ]; then
               curl --output ${OUTPUT} --location --request POST ${ENDPOINT}/rest/v1/workers/${WORKER_NAME}/process --header 'X-Keyfactor-Requested-With: REST' --header 'Accept: application/octet-stream' --form file=@${FILE_PATH} --form 'type=multipart/form-data' --cert-type P12 --cert ${CLIENT_CERT}:${PASSWORD} --insecure
-            elif ["$DISABLE_CERT_VAL" == "false" ]; then
+            elif [ "$DISABLE_CERT_VAL" == "false" ]; then
               curl --output ${OUTPUT} --location --request POST ${ENDPOINT}/rest/v1/workers/${WORKER_NAME}/process --header 'X-Keyfactor-Requested-With: REST' --header 'Accept: application/octet-stream' --form file=@${FILE_PATH} --form 'type=multipart/form-data' --cert-type P12 --cert ${CLIENT_CERT}:${PASSWORD}
             fi
           fi
@@ -74,7 +74,7 @@ runs:
           elif [ "$CLIENT_CERT" != "" ]; then
             if [ "$DISABLE_CERT_VAL" == "true" ]; then
               curl -F workerName=${WORKER_NAME} -F file=@${FILE_PATH} --cert-type P12 --cert ${CLIENT_CERT}:${PASSWORD}  --output ${OUTPUT} ${ENDPOINT}/process --insecure
-            elif ["$DISABLE_CERT_VAL" == "false" ]; then
+            elif [ "$DISABLE_CERT_VAL" == "false" ]; then
               curl -F workerName=${WORKER_NAME} -F file=@${FILE_PATH} --cert-type P12 --cert ${CLIENT_CERT}:${PASSWORD}  --output ${OUTPUT} ${ENDPOINT}/process
             fi
           fi


### PR DESCRIPTION
## Summary
`elif ["$DISABLE_CERT_VAL" == "false" ]` is missing a space after the opening bracket, in both the REST and non-REST branches. Bash parses `["$DISABLE_CERT_VAL"` as a command name (literally `[false` once the variable expands), which fails with "command not found."

Since this happens inside an `elif` condition, `set -e` doesn't propagate the failure — the branch just quietly does nothing instead of running the signing `curl` call, whenever `disable-cert-val` is left at its default (`false`) with a client cert configured. This was a bit tricky to track down since the step reports success either way.

## Fix
Add the missing space in both occurrences: `elif [ "$DISABLE_CERT_VAL" == "false" ]`.

## Test plan
- [x] Reproduced the failure locally by running the exact `run:` script with `DISABLE_CERT_VAL=false` and a client cert set — confirmed `[false: command not found` and no curl invocation
- [x] Confirmed the fixed condition runs the intended curl branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)