### PR TITLE
Clarify that the endpoint input must include the /signserver context path

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The following authentication types are supported:
 
 ### Input parameters
 
-`endpoint`: (Required) The SignServer signing endpoint.
+`endpoint`: (Required) The full SignServer signing endpoint, including the `/signserver` context path (e.g. `https://myhost:8443/signserver`) — see the example below.
 
 `file-path`: (Required) The path to the file to be signed.
 

--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ branding:
 
 inputs:
   endpoint:
-    description: The SignServer signing endpoint.
+    description: The full SignServer signing endpoint, including the /signserver context path (e.g. https://myhost:8443/signserver).
     required: true
   file-path:
     description: The path to the file to be signed


### PR DESCRIPTION
## Summary
The example usage already shows `http://localhost:80/signserver`, but the `endpoint` input's own description (in both `action.yml` and the README's parameter list) just says "The SignServer signing endpoint," with no mention of the required `/signserver` path. If you're going by the parameter description rather than the example, it's easy to pass just the host — the action's curl calls then quietly hit the wrong path.

## Fix
Update the `endpoint` description in `action.yml` and the README's input parameters section to explicitly call out the `/signserver` context path requirement, with an example value. No behavior change, docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)